### PR TITLE
Added the ability to configure the tag that the script applies to files

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1,7 +1,17 @@
-module.exports = api => {
+module.exports = (api, options) => {
   api.extendPackage({
     scripts: {
       'deploy:cleanup': 'vue-cli-service s3-deploy-cleanup'
+    },
+    vue: {
+      pluginOptions: {
+        s3Deploy: {
+          cleanupTag: {
+            Key: options.tagKey,
+            Value: options.tagValue
+          }
+        }
+      }
     }
   })
 }

--- a/generator.js
+++ b/generator.js
@@ -1,11 +1,13 @@
 module.exports = (api, options) => {
   api.extendPackage({
-    scripts: {
+    // Goes into package.json
+    scripts: { 
       'deploy:cleanup': 'vue-cli-service s3-deploy-cleanup'
     },
-    vue: {
+    // Goes into vue.config.js
+    vue: { 
       pluginOptions: {
-        s3Deploy: {
+        s3DeployCleanup: {
           cleanupTag: {
             Key: options.tagKey,
             Value: options.tagValue

--- a/generator.js
+++ b/generator.js
@@ -15,5 +15,16 @@ module.exports = (api, options) => {
         }
       }
     }
-  })
+  });
+
+  // It's a bit inconvenient to have 2 different npm scripts to deploy: one to deploy and one to cleanup.
+  // So give the user the option of making the deploy script do both.
+  if (options.overwriteDeployScript) {
+    api.extendPackage({
+      // Goes into package.json
+      scripts: { 
+        'deploy': 'vue-cli-service s3-deploy && vue-cli-service s3-deploy-cleanup'
+      }
+    }); 
+  }
 }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ module.exports = (api, configOptions) => {
         error('Asset path must be specified with `assetPath` in vue.config.js!');
       } else if (!options.assetMatch) {
         error('Asset match must be specified with `assetMatch` in vue.config.js!');
+      } else if (!options.cleanupTag) {
+        error('Tag must be specified with `cleanupTag` in vue.config.js!');
       }
 
       const cleanBucket = new CleanBucket(options);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,10 @@ module.exports = (api, configOptions) => {
       usage: 'vue-cli-service s3-deploy-cleanup'
     },
     async () => {
-      const options = configOptions.pluginOptions.s3Deploy;
+      const options = {
+        ...configOptions.pluginOptions.s3Deploy,
+        ...configOptions.pluginOptions.s3DeployCleanup
+      };
 
       if (!options.bucket) {
         error('Bucket name must be specified with `bucket` in vue.config.js!');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/prompts.js
+++ b/prompts.js
@@ -11,4 +11,10 @@ module.exports = [
     message: 'What is the value for the tag to be applied to files that need to be cleaned up?',
     default: 'DeleteMe'
   },
+  {
+    name: 'overwriteDeployScript',
+    type: 'boolean',
+    message: 'Would you like to overwrite the default npm/yarn deploy script to include cleanup?',
+    default: false
+  }
 ];

--- a/prompts.js
+++ b/prompts.js
@@ -1,0 +1,14 @@
+module.exports = [
+  {
+    name: 'tagKey',
+    type: 'input',
+    message: 'What is the key for the tag to be applied to files that need to be cleaned up?',
+    default: 'DeployLifecycle'
+  },
+  {
+    name: 'tagValue',
+    type: 'input',
+    message: 'What is the value for the tag to be applied to files that need to be cleaned up?',
+    default: 'DeleteMe'
+  },
+];

--- a/src/clean-bucket.js
+++ b/src/clean-bucket.js
@@ -1,11 +1,6 @@
 const S3Bucket = require('./s3-bucket.js');
 const FileSystem = require('./file-system.js');
 
-const deleteMeTag = {
-    Key: "DeployLifecycle",
-    Value: "DeleteMe"
-};
-
 class CleanBucket {
     
     #s3DeployConfig = null;
@@ -36,7 +31,7 @@ class CleanBucket {
             console.log('Going to tag these S3 objects that are not on the local machine:');
             console.log(s3ObjectsNotOnLocalFileSystem);
 
-            await s3Bucket.addTag(deleteMeTag, s3ObjectsNotOnLocalFileSystem);
+            await s3Bucket.addTag(this.s3DeployConfig.cleanupTag, s3ObjectsNotOnLocalFileSystem);
 
             console.log('Finished tagging');
 


### PR DESCRIPTION
Now, when installing the plugin, the user will be asked for the key/value of the tag to apply, and it's stored in `vue.config.js`.

Also, the user will be asked whether to overwrite the default npm/yarn script that deploys, to have it cleanup afterward as well.