### PR TITLE
Update the last modified date on files that we tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ Note that we have 2 lifecycle rules: one to delete old versions of the same file
 
 4. Deploy your project: `yarn deploy` or `yarn deploy && yarn deploy:cleanup`
 
-You'll see a list of files that the plugin found in S3 and in the dist directory on your local machine. Any files in S3 that are not on your local machine are assumed to be old build artifacts and will be tagged with the tag your specified. Then the lifecycle rule will delete them after the amount of time you specified.
+You'll see a list of files that the plugin found in S3 and in the dist directory on your local machine. Any files in S3 that are not on your local machine are assumed to be old build artifacts and will be tagged with the tag your specified. They will also be copied in place so that their last modified date is updated (the lifecycle rule calculates time based on the object's last modified date, and tagging the object doesn't update this date). Their metadata will be replaced during this copy operation. Once this is done the lifecycle rule will delete them after the amount of time you specified.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/src/clean-bucket.js
+++ b/src/clean-bucket.js
@@ -28,11 +28,19 @@ class CleanBucket {
             // Note that S3 paths are case-sensitive. This check is case-sensitive too. Not sure if this will cause issues in practice.
             const s3ObjectsNotOnLocalFileSystem = s3Objects.filter(x => fileSystemObjects.indexOf(x) < 0); // Note that fileSystemObjects should be fairly short, so even though this is O(N*M), M is at least small
 
-            console.log('Going to tag these S3 objects that are not on the local machine:');
+            console.log('These S3 objects are not on the local machine:');
             console.log(s3ObjectsNotOnLocalFileSystem);
 
-            await s3Bucket.updateObjectModifiedDate(s3ObjectsNotOnLocalFileSystem, this.s3DeployConfig.acl);
-            await s3Bucket.addTag(this.s3DeployConfig.cleanupTag, s3ObjectsNotOnLocalFileSystem);
+            // Note that we don't want to keep re-tagging the same objects over and over. That'll keep updating the last modified date,
+            // and if we do this often enough then the object will never be deleted by S3 because it'll never be "old enough".
+
+            const s3ObjectsThatNeedTagged = await s3Bucket.filterOutObjectsWithTag(s3ObjectsNotOnLocalFileSystem, this.s3DeployConfig.cleanupTag);
+
+            console.log('These S3 objects are not yet tagged:');
+            console.log(s3ObjectsThatNeedTagged);
+
+            await s3Bucket.updateObjectModifiedDate(s3ObjectsThatNeedTagged, this.s3DeployConfig.acl);
+            await s3Bucket.addTag(s3ObjectsThatNeedTagged, this.s3DeployConfig.cleanupTag);
 
             console.log('Finished tagging');
 

--- a/src/clean-bucket.js
+++ b/src/clean-bucket.js
@@ -31,6 +31,7 @@ class CleanBucket {
             console.log('Going to tag these S3 objects that are not on the local machine:');
             console.log(s3ObjectsNotOnLocalFileSystem);
 
+            await s3Bucket.updateObjectModifiedDate(s3ObjectsNotOnLocalFileSystem, this.s3DeployConfig.acl);
             await s3Bucket.addTag(this.s3DeployConfig.cleanupTag, s3ObjectsNotOnLocalFileSystem);
 
             console.log('Finished tagging');

--- a/src/s3-bucket.js
+++ b/src/s3-bucket.js
@@ -12,7 +12,7 @@ class S3Bucket {
     }
 
     getListOfKeysFromS3Bucket(s3Objects) {
-        return s3Objects['Contents'].map(object => object['Key']);
+        return s3Objects.map(object => object['Key']);
     }
 
     getDeployPrefix(deployPath) {
@@ -37,14 +37,28 @@ class S3Bucket {
     async getBucketContents() {
 
         const params = {
-          Bucket: this.bucketName,
-          Prefix: this.deployPrefix,
-          FetchOwner: false,
+          Bucket:       this.bucketName,
+          Prefix:       this.deployPrefix,
+          FetchOwner:   false,
           EncodingType: "url",
           RequestPayer: "requester",
         };
 
-        const s3Objects = await s3.listObjectsV2(params).promise();
+        let moreObjects = true;
+        let s3Objects = [];
+
+        while (moreObjects) {
+
+            const listObjectsResult = await s3.listObjectsV2(params).promise();
+
+            if (listObjectsResult['IsTruncated']) {
+                params.ContinuationToken = listObjectsResult['NextContinuationToken'];
+            } else {
+                moreObjects = false;
+            }
+
+            s3Objects = s3Objects.concat(listObjectsResult['Contents']);
+        }
 
         return this.getListOfKeysFromS3Bucket(s3Objects);
     }
@@ -54,8 +68,8 @@ class S3Bucket {
         // We can only add tags to one S3 object at a time, so do them all in parallel
         const addTagPromises = s3Paths.map(basePath => {
             const params = {
-              Bucket: this.bucketName, 
-              Key: this.deployPrefix + basePath, 
+              Bucket:   this.bucketName, 
+              Key:      this.deployPrefix + basePath, 
               Tagging: {
                 TagSet: [ tag ]
               }
@@ -64,6 +78,32 @@ class S3Bucket {
         });
 
         return Promise.all(addTagPromises);
+    }
+
+    async updateObjectModifiedDate(s3Paths, acl) {
+
+        // Lifecycle rules in S3 only work based off of the object's last modified date,
+        // which is not updated when adding (or removing) a tag. We can force the update of this date
+        // by copying the object onto itself: https://stackoverflow.com/questions/13455168/is-there-a-way-to-touch-file-in-amazon-s3
+        // (thus the need for passing in an ACL: it's the only attribute of the object that isn't copied by default)
+        // Npte the need to update the object's metadata.
+        // Also we will just copy all of the object's tags. We could save a call by setting the tag here rather than with addTag() above,
+        // but that would mean overwriting the existing tags on the object. Better to be safe by copying them all and adding ours later.
+        const copyObjectPromises = s3Paths.map(basePath => {
+            const params = {
+              Bucket:       this.bucketName, 
+              CopySource:   encodeURI(this.bucketName + '/' + this.deployPrefix + basePath),
+              Key:          this.deployPrefix + basePath, 
+              ACL:          acl,
+              MetadataDirective: "REPLACE",
+              Metadata: {
+                "IsCopy": "true"
+              }
+            };
+            return s3.copyObject(params).promise();
+        });
+
+        return Promise.all(copyObjectPromises);
     }
 }
 


### PR DESCRIPTION
S3 doesn't update the last modified date for an object when we add a tag. However, object lifecycle rules are based off of the last modified date. So, without updating the last modified date, if we tag an object and have a rule to delete it in 3 days, if the object is > 3 days old already it'll be deleted right away.

Here we make an in-place copy of the object to force an update to its last modified date. In order to do this, we update the object's metadata.

We also test to make sure that we don't do this multiple times to the same file, or else if we deploy frequently enough its last modified date will be continually updated and it'll never get deleted because it'll never be "old enough".