### PR TITLE
Add support for per-environment overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ resource "aws_s3_bucket" "frontend" {
 
 Note that we have 2 lifecycle rules: one to delete old versions of the same file, and one to delete files with our new tag. This is because some files may be deployed with the same name (e.g. `index.html`) and so will have old versions kept by S3 if versioning is enabled on the bucket.
 
-4. Deploy your project: `yarn deploy` or `yarn deploy && yarn deploy:cleanup`
+4. Deploy your project: `yarn deploy && yarn deploy:cleanup`
 
 You'll see a list of files that the plugin found in S3 and in the dist directory on your local machine. Any files in S3 that are not on your local machine are assumed to be old build artifacts and will be tagged with the tag your specified. They will also be copied in place so that their last modified date is updated (the lifecycle rule calculates time based on the object's last modified date, and tagging the object doesn't update this date). Their metadata will be replaced during this copy operation. Once this is done the lifecycle rule will delete them after the amount of time you specified.
+
+## Environments
+
+Note that you can override the cleanup tag on a per-environment basis by adding the values:
+
+```
+VUE_APP_S3D_CLEANUP_TAG_KEY = <something>
+VUE_APP_S3D_CLEANUP_TAG_VALUE = <something>
+```
+
+To your `.env.<environment>` file, and then invoking the deploy with `yarn deploy --mode=<environment> && yarn deploy:cleanup --mode=<environment>`
+
+This is the same file that holds any overrides for the `vue-cli-plugin-s3-deploy` plugin.

--- a/generator.js
+++ b/generator.js
@@ -16,15 +16,4 @@ module.exports = (api, options) => {
       }
     }
   });
-
-  // It's a bit inconvenient to have 2 different npm scripts to deploy: one to deploy and one to cleanup.
-  // So give the user the option of making the deploy script do both.
-  if (options.overwriteDeployScript) {
-    api.extendPackage({
-      // Goes into package.json
-      scripts: { 
-        'deploy': 'vue-cli-service s3-deploy && vue-cli-service s3-deploy-cleanup'
-      }
-    }); 
-  }
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,24 @@ module.exports = (api, configOptions) => {
         ...configOptions.pluginOptions.s3DeployCleanup
       };
 
+      const env_override_prefix = 'VUE_APP_S3D';
+
+      options.bucket      = process.env[`${env_override_prefix}_BUCKET`]      || options.bucket;
+      options.deployPath  = process.env[`${env_override_prefix}_DEPLOY_PATH`] || options.deployPath;
+      options.assetPath   = process.env[`${env_override_prefix}_ASSET_PATH`]  || options.assetPath;
+      options.assetMatch  = process.env[`${env_override_prefix}_ASSET_MATCH`] || options.assetMatch;
+      options.acl         = process.env[`${env_override_prefix}_ACL`]         || options.acl;
+
+      const override_cleanup_tag_key    = process.env[`${env_override_prefix}_CLEANUP_TAG_KEY`];
+      const override_cleanup_tag_value  = process.env[`${env_override_prefix}_CLEANUP_TAG_VALUE`];
+
+      if (override_cleanup_tag_key && override_cleanup_tag_value) {
+        options.cleanupTag = {
+          Key:    override_cleanup_tag_key,
+          Value:  override_cleanup_tag_value
+        };
+      }
+
       if (!options.bucket) {
         error('Bucket name must be specified with `bucket` in vue.config.js!');
       } else if (!options.deployPath) {
@@ -22,9 +40,11 @@ module.exports = (api, configOptions) => {
         error('Asset path must be specified with `assetPath` in vue.config.js!');
       } else if (!options.assetMatch) {
         error('Asset match must be specified with `assetMatch` in vue.config.js!');
+      } else if (!options.acl) {
+        error('Access control list must be specified with `acl` in vue.config.js!');
       } else if (!options.cleanupTag) {
         error('Tag must be specified with `cleanupTag` in vue.config.js!');
-      }
+      } 
 
       const cleanBucket = new CleanBucket(options);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/prompts.js
+++ b/prompts.js
@@ -10,11 +10,5 @@ module.exports = [
     type: 'input',
     message: 'What is the value for the tag to be applied to files that need to be cleaned up?',
     default: 'DeleteMe'
-  },
-  {
-    name: 'overwriteDeployScript',
-    type: 'boolean',
-    message: 'Would you like to overwrite the default npm/yarn deploy script to include cleanup?',
-    default: false
   }
 ];

--- a/src/clean-bucket.js
+++ b/src/clean-bucket.js
@@ -19,10 +19,10 @@ class CleanBucket {
                 s3Bucket.getBucketContents(), 
                 fileSystem.getDirectoryContents(this.s3DeployConfig.assetMatch)]);
       
-            console.log('Found these files in S3:');
+            console.log(`Found these files in S3 in bucket '${this.s3DeployConfig.bucket}':`);
             console.log(s3Objects);
 
-            console.log('Found these files on the local machine:');
+            console.log(`Found these files on the local machine in directory '${this.s3DeployConfig.assetPath}':`);
             console.log(fileSystemObjects);
 
             // Note that S3 paths are case-sensitive. This check is case-sensitive too. Not sure if this will cause issues in practice.


### PR DESCRIPTION
The plugin now looks at the same environment variables as the `vue-cli-plugin-s3-deploy` plugin does, and so they can be used to override the bucket, and other config values, on a per-environment basis.

Also removed the ability to overwrite the `deploy` npm script because using `&&` doesn't let us pass arguments to both commands, which is needed when changing the environment. For example, `npm deploy --mode=production` would become `npm-cli-service s3-deploy && npm-cli-service s3-deploy-cleanup --mode=production` and so `s3-deploy` wouldn't use the `production` overrides.