### PR TITLE
Added support for changing the AWS profile used

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ module.exports = (api, configOptions) => {
 
       const env_override_prefix = 'VUE_APP_S3D';
 
+      options.awsProfile  = process.env[`${env_override_prefix}_AWS_PROFILE`] || options.awsProfile;
+      options.region      = process.env[`${env_override_prefix}_REGION`]      || options.region;
+      options.endpoint    = process.env[`${env_override_prefix}_ENDPOINT`]    || options.endpoint;
       options.bucket      = process.env[`${env_override_prefix}_BUCKET`]      || options.bucket;
       options.deployPath  = process.env[`${env_override_prefix}_DEPLOY_PATH`] || options.deployPath;
       options.assetPath   = process.env[`${env_override_prefix}_ASSET_PATH`]  || options.assetPath;
@@ -30,6 +33,10 @@ module.exports = (api, configOptions) => {
           Key:    override_cleanup_tag_key,
           Value:  override_cleanup_tag_value
         };
+      }
+
+      if (!options.awsProfile) {
+        options.awsProfile = 'default';
       }
 
       if (!options.bucket) {

--- a/src/clean-bucket.js
+++ b/src/clean-bucket.js
@@ -12,7 +12,9 @@ class CleanBucket {
     async clean() {
 
         try {
-            const s3Bucket = new S3Bucket(this.s3DeployConfig.bucket, this.s3DeployConfig.deployPath);
+            console.log(`Using AWS profile '${this.s3DeployConfig.awsProfile}'`);
+
+            const s3Bucket = new S3Bucket(this.s3DeployConfig.bucket, this.s3DeployConfig.deployPath, this.s3DeployConfig.awsProfile, this.s3DeployConfig.region, this.s3DeployConfig.endpoint);
             const fileSystem = new FileSystem(this.s3DeployConfig.assetPath);
 
             const [s3Objects, fileSystemObjects] = await Promise.all([


### PR DESCRIPTION
Previously, this plugin didn't respect the `awsProfile`, `region`, and `endpoint` configuration parameters in the `vue.config.js` file used by vue-cli-plugin-s3-deploy.

- Added support for the `awsProfile` config param, so you can choose which AWS profile in `~/.aws/credentials` you want to use
- Added support for the `region` config param
- Added support for the `endpoint` config param
