### PR TITLE
Downgraded required node version to 12, published v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {
@@ -33,6 +33,6 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=14"
+    "node": ">=12"
   }
 }


### PR DESCRIPTION
Thanks to feedback here: https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup/issues/8 the plugin works with node 12, so downgraded the required version