### PR TITLE
Fixed bug where key names from bucket were not being url decoded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy-cleanup",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A vue-cli plugin that helps cleanup old build artifacts from S3 by tagging them for later deletion",
   "homepage": "https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup",
   "repository": {

--- a/src/s3-bucket.js
+++ b/src/s3-bucket.js
@@ -91,7 +91,9 @@ class S3Bucket {
             s3Objects = s3Objects.concat(listObjectsResult['Contents']);
         }
 
-        const s3Keys = this.getListOfKeysFromS3Bucket(s3Objects);
+        const s3KeysUrlEncoded = this.getListOfKeysFromS3Bucket(s3Objects);
+
+        const s3Keys = s3KeysUrlEncoded.map(x => decodeURIComponent(x));
 
         return this.removeDeployPrefixFromKeys(s3Keys);
     }


### PR DESCRIPTION
This fixes https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup/issues/10

We were getting back the key names url encoded, but then not decoding them.

Tested by manually adding a file with an `@` in our `dist` directory, similarly to the log files from the issue